### PR TITLE
OSFUSE-690: spring-boot-camel-infinispan quickstart should change cache name

### DIFF
--- a/src/main/resources/spring/camel-context.xml
+++ b/src/main/resources/spring/camel-context.xml
@@ -39,7 +39,7 @@
             <setHeader headerName="CamelInfinispanOperation" id="route-header-infinispan-operation">
                 <constant>CamelInfinispanOperationGet</constant>
             </setHeader>
-            <to id="route-infinispan-cache-lookup" uri="infinispan:remote?cacheContainer=#remoteCacheContainer"/>
+            <to id="route-infinispan-cache-lookup" uri="infinispan:default?cacheContainer=#remoteCacheContainer"/>
             <choice id="route-cache-choice">
                 <when id="route-cache-hit">
                     <simple>${header.CamelInfinispanOperationResult} != null</simple>


### PR DESCRIPTION
Uri syntax has changed in camel 2.19 so we should set a meaningful name
instead of simple remote in the infinispan uri as now it identify the 
cache name