### PR TITLE
ENTESB-16564 spring-boot-camel-infinispan-archetype errors using JDK11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,6 @@
         <fuse.bom.version>7.8.0.fuse-sb2-780033</fuse.bom.version>
         <docker.image.version>1.9</docker.image.version>
 
-        <infinispan-client.version>7.2.5.Final</infinispan-client.version>
-
         <!-- maven plugin versions -->
         <maven-compiler-plugin.version>3.6.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
@@ -88,22 +86,18 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>
-            <version>${infinispan-client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-commons</artifactId>
-            <version>${infinispan-client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-query-dsl</artifactId>
-            <version>${infinispan-client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-client-hotrod</artifactId>
-            <version>${infinispan-client.version}</version>
         </dependency>
 
         <!-- For auto-configuration of quickstart properties -->


### PR DESCRIPTION
Issue https://issues.redhat.com/browse/ENTESB-16564

Quickstart contains old version of infinispan, which does not work in java 11. This PR is aligning it with fuse bom.

(cherry-picked - https://github.com/fabric8-quickstarts/spring-boot-camel-infinispan/pull/123 - to the 7.9 branch)